### PR TITLE
Update Mod to 1.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "fabric-loom" version "0.11-SNAPSHOT"
+    id "fabric-loom" version "1.2-SNAPSHOT"
     id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,12 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.19.2
-yarn_mappings=1.19.2+build.10
-loader_version=0.14.9
+minecraft_version=1.20
+yarn_mappings=1.20+build.1
+loader_version=0.14.21
 
 #Fabric api
-fabric_version=0.60.0+1.19.2
+fabric_version=0.83.0+1.20
 
 # Mod Properties
 mod_version=1.1.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/aeltumn/togglesprintdisplay/mixin/GuiMixin.java
+++ b/src/main/java/com/aeltumn/togglesprintdisplay/mixin/GuiMixin.java
@@ -1,9 +1,9 @@
 package com.aeltumn.togglesprintdisplay.mixin;
 
-import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.Gui;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -17,7 +17,7 @@ public class GuiMixin {
     @Shadow @Final private Minecraft minecraft;
 
     @Inject(method = "renderSavingIndicator", at = @At("RETURN"))
-    private void injected(PoseStack poseStack, CallbackInfo ci) {
+    private void injected(GuiGraphics guiGraphics, CallbackInfo ci) {
         Gui gui = (Gui) ((Object) this);
         Font font = gui.getFont();
 
@@ -28,6 +28,6 @@ public class GuiMixin {
         boolean toggleSprint = minecraft.options.toggleSprint().get();
         Component text = Component.translatable("menu.toggle_sprint_display." + (toggleSprint ? "toggle" : "hold") + "_" + (isSprinting ? "on" : "off"));
         int k = 16777215;
-        font.drawShadow(poseStack, text, 7.5f, 7.5f, k);
+        guiGraphics.drawString(font, text, 7, 7, k);
     }
 }


### PR DESCRIPTION
This MR updates dependencies and tools while also updating Mixins to reflect the latest GUI changes.

Full Changelog: 
- Fabric Loom: 0.11 -> 1.2 (latest, see https://github.com/FabricMC/fabric-loom/releases )
- Minecraft: 1.19.2 -> 1.20 (incl. fabric version bumps, taken from: https://fabricmc.net/develop/ )
- fabric loader: 0.14.9 -> 0.14.21
- Gradle: 7.4.2 -> 8.1.1 (Loom 1.2 requires 8.1) 
- PoseStack got replaced by GuiGraphics in the injected method